### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/cors/resources/preflight.py
+++ b/cors/resources/preflight.py
@@ -4,7 +4,7 @@ def main(request, response):
     if "check" in request.GET:
         token = request.GET.first("token")
         value = request.server.stash.take(token)
-        if value == None:
+        if value is None:
             body = "0"
         else:
             if request.GET.first("check", None) == "keep":

--- a/fetch/nosniff/resources/css.py
+++ b/fetch/nosniff/resources/css.py
@@ -8,7 +8,7 @@ def main(request, response):
     response.writer.write_status(200)
     response.writer.write_header("x-content-type-options", "nosniff")
     response.writer.write_header("content-length", len(content))
-    if(type != None):
+    if(type is not None):
       response.writer.write_header("content-type", type)
     response.writer.end_headers()
 

--- a/fetch/nosniff/resources/image.py
+++ b/fetch/nosniff/resources/image.py
@@ -9,7 +9,7 @@ def main(request, response):
     response.writer.write_status(200)
     response.writer.write_header("x-content-type-options", "nosniff")
     response.writer.write_header("content-length", len(body))
-    if(type != None):
+    if(type is not None):
       response.writer.write_header("content-type", type)
     response.writer.end_headers()
 

--- a/fetch/nosniff/resources/worker.py
+++ b/fetch/nosniff/resources/worker.py
@@ -9,7 +9,7 @@ def main(request, response):
     response.writer.write_status(200)
     response.writer.write_header("x-content-type-options", "nosniff")
     response.writer.write_header("content-length", len(content))
-    if(type != None):
+    if(type is not None):
       response.writer.write_header("content-type", type)
     response.writer.end_headers()
 

--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py
@@ -11,6 +11,6 @@ def main(request, response):
         return [("Content-Type", "text/html")], 'Put %s' % q
     else:
         q = request.server.stash.take(key)
-        if q != None:
+        if q is not None:
             return [("Content-Type", "text/html")], q
         return [], ""

--- a/html/tools/update_html5lib_tests.py
+++ b/html/tools/update_html5lib_tests.py
@@ -52,7 +52,7 @@ def get_expected(data):
     return data
 
 def get_hash(data, container=None):
-    if container == None:
+    if container is None:
         container = ""
     return hashlib.sha1("#container%s#data%s"%(container.encode("utf8"),
                                                data.encode("utf8"))).hexdigest()

--- a/referrer-policy/generic/subresource/subresource.py
+++ b/referrer-policy/generic/subresource/subresource.py
@@ -79,7 +79,7 @@ def respond(request,
     response.add_required_headers = False
     response.writer.write_status(status_code)
 
-    if access_control_allow_origin != None:
+    if access_control_allow_origin is not None:
         response.writer.write_header("access-control-allow-origin",
                                      access_control_allow_origin)
     response.writer.write_header("content-type", content_type)

--- a/referrer-policy/generic/tools/generate.py
+++ b/referrer-policy/generic/tools/generate.py
@@ -85,7 +85,7 @@ def generate_selection(selection, spec, subresource_path,
 
     selection['meta_delivery_method'] = ''
 
-    if spec['referrer_policy'] != None:
+    if spec['referrer_policy'] is not None:
         if selection['delivery_method'] == 'meta-referrer':
             selection['meta_delivery_method'] = \
                 '<meta name="referrer" content="%(referrer_policy)s">' % spec


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:web-platform-tests?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:web-platform-tests?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
